### PR TITLE
Fixed herotag issue when setting transitionBetweenRoutes to true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## [0.3.2] - Oct 11, 2018
+## [0.3.4] - Oct 11, 2018
+
+* Fixed herotag issue when setting transitionBetweenRoutes to true
+
+## [0.3.3] - Oct 11, 2018
 
 * Added transitionBetweenRoutes and heroTag as attributes to CupertinoNavigationBarData
 

--- a/lib/src/platform_app_bar.dart
+++ b/lib/src/platform_app_bar.dart
@@ -22,16 +22,6 @@ const Border _kDefaultNavBarBorder = const Border(
   ),
 );
 
-// There's a single tag for all instances of navigation bars because they can
-// all transition between each other (per Navigator) via Hero transitions.
-const _HeroTag _defaultHeroTag = _HeroTag();
-
-class _HeroTag {
-  const _HeroTag();
-  // Let the Hero tag be described in tree dumps.
-  @override
-  String toString() => 'Default Hero tag for Cupertino navigation bars';
-}
 
 abstract class _BaseData {
   _BaseData({this.title, this.backgroundColor, this.leading});
@@ -162,6 +152,25 @@ class PlatformAppBar
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: trailingActions,
     );
+
+    if(data?.heroTag != null){
+      return CupertinoNavigationBar(
+        middle: data?.title ?? title,
+        backgroundColor: data?.backgroundColor ??
+            backgroundColor ??
+            _kDefaultNavBarBackgroundColor,
+        actionsForegroundColor:
+        data?.actionsForegroundColor ?? CupertinoColors.activeBlue,
+        automaticallyImplyLeading: data?.automaticallyImplyLeading ?? true,
+        border: data?.border ?? _kDefaultNavBarBorder,
+        key: widgetKey,
+        leading: data?.leading ?? leading,
+        trailing: data?.trailing ?? trailing,
+        transitionBetweenRoutes: data?.transitionBetweenRoutes ?? true,
+        heroTag: data.heroTag,
+      );
+    }
+
     return CupertinoNavigationBar(
       middle: data?.title ?? title,
       backgroundColor: data?.backgroundColor ??
@@ -175,7 +184,6 @@ class PlatformAppBar
       leading: data?.leading ?? leading,
       trailing: data?.trailing ?? trailing,
       transitionBetweenRoutes: data?.transitionBetweenRoutes ?? true,
-      heroTag: data?.heroTag ?? _defaultHeroTag,
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_platform_widgets
 description: Simplifying the use of both Material and Cupertino widgets with a single widget
-version: 0.3.3
+version: 0.3.4
 author: Lance Johnstone <flutterlance@outlook.com>
 homepage: https://github.com/aqwert/flutter_platform_widgets
 


### PR DESCRIPTION
Sorry for the late reply, testing it on a real iPhone revealed an issue with the DefaultHero class.
The class is private in the navBar. I copied it to the PlatformNavBar, but an assert statement in navbar compares the references instead of the String values.

So I needed to add an if expression to check whether a hero tag was set by the user. Otherwise the optional parameter will not be used resulting in the private instance of default _HeroTag

#9 