### PR TITLE
Temporary fix for flutter-web compatibility.

### DIFF
--- a/lib/src/platform.dart
+++ b/lib/src/platform.dart
@@ -6,6 +6,7 @@
 
 import 'dart:io' show Platform;
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/cupertino.dart' show showCupertinoDialog;
 import 'package:flutter/material.dart' show showDialog;
 import 'package:flutter/widgets.dart';
@@ -33,13 +34,27 @@ bool get isMaterial =>
 bool get isCupertino =>
     _forceCupertino || (!_forceMaterial && _isCupertinoCompatible);
 
-bool get _isMaterialCompatible =>
-    Platform.isWindows ||
-    Platform.isAndroid ||
-    Platform.isFuchsia ||
-    Platform.isLinux;
+bool get isWeb => kIsWeb;
 
-bool get _isCupertinoCompatible => Platform.isIOS || Platform.isMacOS;
+bool get _isMaterialCompatible {
+  if (kIsWeb) {
+    return true;
+  } else {
+    return
+      Platform.isWindows ||
+      Platform.isAndroid ||
+      Platform.isFuchsia ||
+      Platform.isLinux;
+  }
+}
+
+bool get _isCupertinoCompatible {
+  if (kIsWeb) {
+    return true;
+  } else {
+    return Platform.isIOS || Platform.isMacOS;
+  }
+}
 
 Future<T> showPlatformDialog<T>({
   @required BuildContext context,


### PR DESCRIPTION
Compiling for web currently [fails](https://github.com/flutter/flutter/issues/36126) because of the use of dart:io (used as Platform.is* in platform.dart), which is not supported for web. [Discussion](https://github.com/dart-lang/sdk/issues/35969)

So far there doesn't seem to be anything like Platform.isWeb. Also what style should be used for web is questionable, perhaps making it Material by default for now is the best idea and users should be still able to switch between Material/Cuportino if they wish (again not sure if web supports Cuportino at this point).

This PR works around the Platform.* statements by utilizing the temporary(?) constant [kIsWeb](https://github.com/flutter/flutter/pull/36135) from Flutter foundation.