### PR TITLE
Use the same placeholderStyle that CupertinoTextField defaults to

### DIFF
--- a/lib/src/platform_text_field.dart
+++ b/lib/src/platform_text_field.dart
@@ -409,7 +409,11 @@ class PlatformTextField
       clearButtonMode: data?.clearButtonMode ?? OverlayVisibilityMode.never,
       padding: data?.padding ?? const EdgeInsets.all(6.0),
       placeholder: data?.placeholder,
-      placeholderStyle: data?.placeholderStyle,
+      placeholderStyle: data?.placeholderStyle ??
+          const TextStyle(
+            fontWeight: FontWeight.w400,
+            color: CupertinoColors.placeholderText,
+          ),
       prefix: data?.prefix,
       prefixMode: data?.prefixMode ?? OverlayVisibilityMode.always,
       suffix: data?.suffix,


### PR DESCRIPTION
When using a PlatformTextField with a placeholder, the placeholder text is black on iOS. This changes the placeholder style to the same style used by CupertinoTextField.