### PR TITLE
Update ot example  main.dart to fix ios localization errors

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -56,6 +56,11 @@ class _AppState extends State<App> {
 
     return PlatformProvider(
       builder: (context) => PlatformApp(
+          localizationsDelegates: <LocalizationsDelegate<dynamic>>[
+          DefaultMaterialLocalizations.delegate,
+          DefaultWidgetsLocalizations.delegate,
+          DefaultCupertinoLocalizations.delegate,
+        ],
         title: 'Flutter Platform Widgets',
         android: (_) {
           return new MaterialAppData(


### PR DESCRIPTION
these 3 lines fixes the localization error warning on ios ie overlays

yeah my first contribution to a flutter plugin :)