### PR TITLE
Fix PlatformTabScaffold ignoring androidTabs Data

### DIFF
--- a/lib/src/platform_tab_scaffold.dart
+++ b/lib/src/platform_tab_scaffold.dart
@@ -203,6 +203,7 @@ class PlatformTabScaffold extends PlatformWidgetBase<Widget, Widget> {
       items: items,
       backgroundColor: data?.tabsBackgroundColor ?? tabsBackgroundColor,
       currentIndex: controller?.index ?? currentIndex,
+      android: androidTabs,
       itemChanged: (int index) {
         controller?.index = index;
         itemChanged?.call(index);
@@ -255,7 +256,6 @@ class PlatformTabScaffold extends PlatformWidgetBase<Widget, Widget> {
       backgroundColor: tabsBackgroundColor,
       currentIndex: currentIndex,
       itemChanged: itemChanged,
-      android: androidTabs,
       ios: iosTabs,
     );
     final tabBar = navBar.createIosWidget(context);


### PR DESCRIPTION
This commit fixes the neglect of properties passed to the android nav bar through the androidTabs data property

ref #129 