### PR TITLE
Update platform_scaffold.dart

### DIFF
--- a/lib/src/platform_scaffold.dart
+++ b/lib/src/platform_scaffold.dart
@@ -153,7 +153,7 @@ class PlatformScaffold extends PlatformWidgetBase<Widget, Scaffold> {
       floatingActionButtonLocation: data?.floatingActionButtonLocation,
       persistentFooterButtons: data?.persistentFooterButtons,
       primary: data?.primary ?? true,
-      resizeToAvoidBottomPadding: data?.resizeToAvoidBottomPadding,
+      resizeToAvoidBottomInset: data?.resizeToAvoidBottomPadding,
       bottomSheet: data?.bottomSheet,
       drawerDragStartBehavior:
           data?.drawerDragStartBehavior ?? DragStartBehavior.start,


### PR DESCRIPTION
from the pub analysis tool their report said:
Analysis of lib/src/platform_scaffold.dart reported 1 hint:

line 156 col 41: 'resizeToAvoidBottomPadding' is deprecated and shouldn't be used. Use resizeToAvoidBottomInset to specify if the body should resize when the keyboard appears. This feature was deprecated after v1.1.9..