### PR TITLE
Update platform_tab_scaffold.dart

### DIFF
--- a/lib/src/platform_tab_scaffold.dart
+++ b/lib/src/platform_tab_scaffold.dart
@@ -232,7 +232,7 @@ class PlatformTabScaffold extends PlatformWidgetBase<Widget, Widget> {
       floatingActionButtonLocation: data?.floatingActionButtonLocation,
       persistentFooterButtons: data?.persistentFooterButtons,
       primary: data?.primary ?? true,
-      resizeToAvoidBottomPadding: data?.resizeToAvoidBottomPadding,
+      resizeToAvoidBottomInset: data?.resizeToAvoidBottomPadding,
       bottomSheet: data?.bottomSheet,
       drawerDragStartBehavior:
           data?.drawerDragStartBehavior ?? DragStartBehavior.start,


### PR DESCRIPTION
from pub analysis tool report:
Analysis of lib/src/platform_tab_scaffold.dart reported 1 hint:

line 235 col 41: 'resizeToAvoidBottomPadding' is deprecated and shouldn't be used. Use resizeToAvoidBottomInset to specify if the body should resize when the keyboard appears. This feature was deprecated after v1.1.9..