### PR TITLE
bug: PlatformScafold should prefer body of CupertinoPageScaffoldData

### DIFF
--- a/lib/src/platform_scaffold.dart
+++ b/lib/src/platform_scaffold.dart
@@ -172,7 +172,7 @@ class PlatformScaffold extends PlatformWidgetBase<Widget, Scaffold> {
       data = ios(context);
     }
 
-    Widget child = body ?? data?.body;
+    Widget child = data?.body ?? body;
     var navigationBar = appBar?.createIosWidget(context) ?? data?.navigationBar;
 
     Widget result;


### PR DESCRIPTION
Currently PlatformScafold does not use the recieved body of CupertinoPageScaffoldData if the body parameter of PlatformScafold is used. This pull request should fix the problem.