### PR TITLE
support cupertino filled buttons as button type

### DIFF
--- a/lib/src/platform_button.dart
+++ b/lib/src/platform_button.dart
@@ -301,6 +301,25 @@ class PlatformButton
 
   @override
   CupertinoButton createIosWidget(BuildContext context) {
+    CupertinoFilledButtonData filledData;
+    if (iosFilled != null) {
+      filledData = iosFilled(context);  
+        
+      return CupertinoButton.filled(
+        key: data?.widgetKey ?? widgetKey,
+        child: data?.child ?? child,
+        onPressed: data?.onPressed ?? onPressed,
+        borderRadius: data?.borderRadius ??
+            const BorderRadius.all(const Radius.circular(8.0)),
+        minSize: data?.minSize ?? _kMinInteractiveDimensionCupertino,
+        padding: data?.padding ?? padding,
+        pressedOpacity: data?.pressedOpacity ?? 0.4,
+        disabledColor: data?.disabledColor ??
+            disabledColor ??
+            CupertinoColors.quaternarySystemFill,
+      );
+    }    
+      
     CupertinoButtonData data;
     if (ios != null) {
       data = ios(context);
@@ -313,25 +332,6 @@ class PlatformButton
       borderRadius: data?.borderRadius ??
           const BorderRadius.all(const Radius.circular(8.0)),
       color: data?.color ?? color,
-      minSize: data?.minSize ?? _kMinInteractiveDimensionCupertino,
-      padding: data?.padding ?? padding,
-      pressedOpacity: data?.pressedOpacity ?? 0.4,
-      disabledColor: data?.disabledColor ??
-          disabledColor ??
-          CupertinoColors.quaternarySystemFill,
-    );
-      
-    CupertinoFilledButtonData filledData;
-    if (iosFilled != null) {
-      filledData = iosFilled(context);  
-    }
-      
-    return CupertinoButton.filled(
-      key: data?.widgetKey ?? widgetKey,
-      child: data?.child ?? child,
-      onPressed: data?.onPressed ?? onPressed,
-      borderRadius: data?.borderRadius ??
-          const BorderRadius.all(const Radius.circular(8.0)),
       minSize: data?.minSize ?? _kMinInteractiveDimensionCupertino,
       padding: data?.padding ?? padding,
       pressedOpacity: data?.pressedOpacity ?? 0.4,

--- a/lib/src/platform_button.dart
+++ b/lib/src/platform_button.dart
@@ -182,6 +182,29 @@ class CupertinoButtonData extends _BaseData {
   final double pressedOpacity;
 }
 
+class CupertinoFilledButtonData extends _BaseData {
+  CupertinoButtonData(
+      {Key widgetKey,
+      Widget child,
+      VoidCallback onPressed,
+      EdgeInsetsGeometry padding,
+      Color disabledColor,
+      this.borderRadius,
+      this.minSize,
+      this.pressedOpacity})
+      : super(
+            widgetKey: widgetKey,
+            child: child,
+            color: color,
+            onPressed: onPressed,
+            padding: padding,
+            disabledColor: disabledColor);
+
+  final BorderRadius borderRadius;
+  final double minSize;
+  final double pressedOpacity;
+}
+
 class PlatformButton
     extends PlatformWidgetBase<CupertinoButton, MaterialButton> {
   final Key widgetKey;
@@ -195,6 +218,7 @@ class PlatformButton
   final PlatformBuilder<MaterialRaisedButtonData> android;
   final PlatformBuilder<MaterialFlatButtonData> androidFlat;
   final PlatformBuilder<CupertinoButtonData> ios;
+  final PlatformBuilder<CupertinoFilledButtonData> iosFilled;
 
   PlatformButton(
       {Key key,
@@ -290,6 +314,25 @@ class PlatformButton
       borderRadius: data?.borderRadius ??
           const BorderRadius.all(const Radius.circular(8.0)),
       color: data?.color ?? color,
+      minSize: data?.minSize ?? _kMinInteractiveDimensionCupertino,
+      padding: data?.padding ?? padding,
+      pressedOpacity: data?.pressedOpacity ?? 0.4,
+      disabledColor: data?.disabledColor ??
+          disabledColor ??
+          CupertinoColors.quaternarySystemFill,
+    );
+      
+    CupertinoFilledButtonData filledData;
+    if (iosFilled != null) {
+      filledData = iosFilled(context);  
+    }
+      
+    return CupertinoButton.filled(
+      key: data?.widgetKey ?? widgetKey,
+      child: data?.child ?? child,
+      onPressed: data?.onPressed ?? onPressed,
+      borderRadius: data?.borderRadius ??
+          const BorderRadius.all(const Radius.circular(8.0)),
       minSize: data?.minSize ?? _kMinInteractiveDimensionCupertino,
       padding: data?.padding ?? padding,
       pressedOpacity: data?.pressedOpacity ?? 0.4,

--- a/lib/src/platform_button.dart
+++ b/lib/src/platform_button.dart
@@ -195,7 +195,6 @@ class CupertinoFilledButtonData extends _BaseData {
       : super(
             widgetKey: widgetKey,
             child: child,
-            color: color,
             onPressed: onPressed,
             padding: padding,
             disabledColor: disabledColor);


### PR DESCRIPTION
PlatformButton supports multiple android button types, but not ios filled type. This add the filled type as an option.